### PR TITLE
fix: return firebase paths correctly

### DIFF
--- a/src/sdk/firebaseClient.js
+++ b/src/sdk/firebaseClient.js
@@ -15,7 +15,11 @@ async function getFirebasePaths() {
     ];
 
     return Object.keys(data || {}).reduce(
-      (accu, key) => knownPaths.includes(key)
+      (accu, key) => {
+        if (knownPaths.includes(key)) accu.push(key);
+        return accu;
+      },
+      []
     );
   } catch (error) {
     console.error("“Firebase path fetch error:", error.message);


### PR DESCRIPTION
## Summary
- accumulate firebase paths when fetching from firebase

## Testing
- `npm test` *(fails: Missing script "test")*