### PR TITLE
docs: fix healthcheck typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A locally tested API Gateway deployed to Cloud Run with auto-scaling, GitHub act
 - /gbt
   /notion
   /ping/trace
-  /   (endpoint, healtcheck test)
+  /   (endpoint, healthcheck test)
 
 - Notion server route confirms to be receiving regular REQ structure and JSON
 


### PR DESCRIPTION
## Summary
- fix a typo in the README routes list

## Testing
- `grep -n healthcheck README.md`
