### PR TITLE
Fix GitHub route paths

### DIFF
--- a/src/GitHubRoutes/codespaces.js
+++ b/src/GitHubRoutes/codespaces.js
@@ -11,13 +11,15 @@ const router = express.Router();
 router.get('/codespaces', async (req, res) => {
   try {
     const { data } = await octokit.codespaces.listForAuthenticatedUser();
-    res.json( data.codespaces.map(cs => ({
-      id: cs.id,
-      name: cs.name,
-      state: cs.state,
-      created_at: cs.created_at,
-      repo: cs.repository.full_name
-    }) )
+    res.json(
+      data.codespaces.map(cs => ({
+        id: cs.id,
+        name: cs.name,
+        state: cs.state,
+        created_at: cs.created_at,
+        repo: cs.repository.full_name
+      }))
+    );
   } catch (error) {
     console.error('listCodespaces error:', typeof error === 'object' ? error.message : error);
     res.status(500).json( { error: 'Failed to list codespaces' });

--- a/src/GitHubRoutes/deploys.js
+++ b/src/GitHubRoutes/deploys.js
@@ -8,7 +8,7 @@ const octokit = new Octokit({
 const router = express.Router();
 
 // List recent deployments
-router.get('/deploys/:owner:repo', async (req, res) => {
+router.get('/deploys/:owner/:repo', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const { data } = await octokit.repos.listDeployments({
@@ -24,7 +24,7 @@ router.get('/deploys/:owner:repo', async (req, res) => {
 });
 
 // Trigger a new deployment
-router.post('/deploys:/owner:repo', async (req, res) => {
+router.post('/deploys/:owner/:repo', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const { ref, environment, description } = req.body;
@@ -49,7 +49,7 @@ router.post('/deploys:/owner:repo', async (req, res) => {
 });
 
 // Get deployment statuses
-router.get('/deploys:/owner:repo/:deployment_id/status', async (req, res) => {
+router.get('/deploys/:owner/:repo/:deployment_id/status', async (req, res) => {
   try {
     const { owner, repo, deployment_id } = req.params;
     const { data } = await octokit.repos.listDeploymentStatuses({

--- a/src/GitHubRoutes/files.js
+++ b/src/GitHubRoutes/files.js
@@ -8,9 +8,10 @@ const octokit = new Octokit({
 const router = express.Router();
 
 // Read a file
-router.get('/files/:owner:repo/:path*()', async (req, res) => {
+router.get('/files/:owner/:repo/*', async (req, res) => {
   try {
-    const { owner, repo, path } = req.params;
+    const { owner, repo } = req.params;
+    const path = req.params[0];
     const { data } = await octokit.repos.getContent({owner, repo, path });
     const fileContent = Buffer.from(data.content, 'base64').toString('utf-8');
     res.json({ name: data.name, content: fileContent });
@@ -21,9 +22,10 @@ router.get('/files/:owner:repo/:path*()', async (req, res) => {
 });
 
 // Write or update a file
-router.put('/files/:owner:repo/:path*()', async (req, res) => {
+router.put('/files/:owner/:repo/*', async (req, res) => {
   try {
-    const { owner, repo, path } = req.params;
+    const { owner, repo } = req.params;
+    const path = req.params[0];
     const { content, message, sha } = req.body;
     const encoded = Buffer.from(content).toString('base64');
 
@@ -36,7 +38,7 @@ router.put('/files/:owner:repo/:path*()', async (req, res) => {
       sha
     });
 
-    res.json({ status: 'written", data: result.data });
+    res.json({ status: 'written', data: result.data });
   } catch (error) {
     console.error('writeFile error:', typeof error === 'object' ? error.message : error);
     res.status(500).json( { error: 'Failed to write file' });
@@ -44,9 +46,10 @@ router.put('/files/:owner:repo/:path*()', async (req, res) => {
 });
 
 // Delete a file
-router.delete('/files/:owner:/repo/:path(())', async (req, res) => {
+router.delete('/files/:owner/:repo/*', async (req, res) => {
   try {
-    const { owner, repo, path } = req.params;
+    const { owner, repo } = req.params;
+    const path = req.params[0];
     const { message, sha } = req.body;
 
     const result = await octokit.repos.deleteFile({

--- a/src/GitHubRoutes/gists.js
+++ b/src/GitHubRoutes/gists.js
@@ -17,7 +17,7 @@ router.get('/gists', async (req, res) => {
       public: gist.public,
       files: Object.keys(gist.files),
       created_at: gist.created_at
-    }));
+    })));
   } catch (error) {
     console.error('listGists error:', typeof error === 'object' ? error.message : error);
     res.status(500).json( { error: 'Failed to list gists' });

--- a/src/GitHubRoutes/hooks.js
+++ b/src/GitHubRoutes/hooks.js
@@ -8,7 +8,7 @@ const octokit = new Octokit({
 const router = express.Router();
 
 // List webhooks
-router.get('/hooks/:owner:repo', async (req, res) => {
+router.get('/hooks/:owner/:repo', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const { data } = await octokit.repos.listWebhooks({
@@ -23,7 +23,7 @@ router.get('/hooks/:owner:repo', async (req, res) => {
 });
 
 // Create a webhook
-router.post('/hooks/:owner:repo/create', async (req, res) => {
+router.post('/hooks/:owner/:repo/create', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const { url, events } = req.body;
@@ -48,7 +48,7 @@ router.post('/hooks/:owner:repo/create', async (req, res) => {
 });
 
 // Delete a webhook
-router.delete('/hooks/:owner:repo/:hook_id', async (req, res) => {
+router.delete('/hooks/:owner/:repo/:hook_id', async (req, res) => {
   try {
     const { owner, repo, hook_id } = req.params;
     await octokit.repos.deleteWebhook({
@@ -56,7 +56,7 @@ router.delete('/hooks/:owner:repo/:hook_id', async (req, res) => {
      , repo
      , hook_id
     });
-    res.json( { status: 'deleted", id: hook_id });
+  res.json({ status: 'deleted', id: hook_id });
   } catch (error) {
     console.error('deleteHook error:', new Error(error));
     res.status(500).json( { error: 'Failed to delete webhook' });

--- a/src/GitHubRoutes/issues.js
+++ b/src/GitHubRoutes/issues.js
@@ -8,7 +8,7 @@ const octokit = new Octokit({
 const router = express.Router();
 
 // List issues for a repository
-router.get('/issues/:owner:repo', async (req, res) => {
+router.get('/issues/:owner/:repo', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const { data } = await octokit.issues.listForRepo({
@@ -31,7 +31,7 @@ router.get('/issues/:owner:repo', async (req, res) => {
 });
 
 // Get details for a specific issue
-router.get('/issues/:owner:repo/:issue_number', async (req, res) => {
+router.get('/issues/:owner/:repo/:issue_number', async (req, res) => {
   try {
     const { owner, repo, issue_number } = req.params;
     const { data } = await octokit.issues.get({
@@ -47,7 +47,7 @@ router.get('/issues/:owner:repo/:issue_number', async (req, res) => {
 });
 
 // Create a new issue
-router.post('/issues/:owner:repo/create', async (req, res) => {
+router.post('/issues/:owner/:repo/create', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const { title, body } = req.body;

--- a/src/GitHubRoutes/repos.js
+++ b/src/GitHubRoutes/repos.js
@@ -24,7 +24,7 @@ router.get('/repos', async (req, res) => {
 });
 
 // Get metadata for a specific repo
-router.get('/repos/:owner:repo', async (req, res) => {
+router.get('/repos/:owner/:repo', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const { data } = await octokit.repos.get({ owner, repo });

--- a/src/GitHubRoutes/secrets.js
+++ b/src/GitHubRoutes/secrets.js
@@ -11,8 +11,8 @@ const router = express.Router();
 // List secrets in a repo
 router.get('/secrets/:owner/:repo', async (req, res) => {
   try {
-    const { owner, repo } = req.params;
-    const { data } = await octokit.actions.listRepoSecrets({oner, repo});
+  const { owner, repo } = req.params;
+  const { data } = await octokit.actions.listRepoSecrets({ owner, repo });
     res.json(data.secrets);
   } catch (error) {
     console.error('listSecrets error:', error);
@@ -49,7 +49,7 @@ router.post('/secrets/:owner/:repo/:name', async (req, res) => {
 });
 
 // Delete a secret
-router.delete('/secrets/:owner:repo/:name', async (req, res) => {
+router.delete('/secrets/:owner/:repo/:name', async (req, res) => {
   try {
     const { owner, repo, name } = req.params;
     await octokit.actions.deleteRepoSecret({ owner, repo, secret_name: name });

--- a/src/GitHubRoutes/settings.js
+++ b/src/GitHubRoutes/settings.js
@@ -8,7 +8,7 @@ const octokit = new Octokit({
 const router = express.Router();
 
 // Get repo settings
-router.get('/settings/:owner:repo', async (req, res) => {
+router.get('/settings/:owner/:repo', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const { data } = await octokit.repos.get({ owner, repo });
@@ -29,7 +29,7 @@ router.get('/settings/:owner:repo', async (req, res) => {
 });
 
 // Update repo settings
-router.patch('/settings/:owner:repo', async (req, res) => {
+router.patch('/settings/:owner/:repo', async (req, res) => {
   try {
     const { owner, repo } = req.params;
     const settings = req.body;

--- a/src/GitHubRoutes/workflows.js
+++ b/src/GitHubRoutes/workflows.js
@@ -8,10 +8,10 @@ const octokit = new Octokit({
 const router = express.Router();
 
 // List all workflows in a repo
-router.get('/workflows/:owner:repo', async (req, res) => {
+router.get('/workflows/:owner/:repo', async (req, res) => {
   try {
     const { owner, repo } = req.params;
-    const { data } = await octokit.actions.listRepoWorkflows({oner, repo});
+    const { data } = await octokit.actions.listRepoWorkflows({ owner, repo });
     res.json(data.workflows);
   } catch (error) {
     console.error('listWorkflows error:', error);
@@ -20,7 +20,7 @@ router.get('/workflows/:owner:repo', async (req, res) => {
 });
 
 // Trigger a workflow manually
-router.post('/workflows/:owner:repo/:workflow_id/run', async (req, res) => {
+router.post('/workflows/:owner/:repo/:workflow_id/run', async (req, res) => {
   try {
     const { owner, repo, workflow_id } = req.params;
     const { ref } = req.body;
@@ -40,7 +40,7 @@ router.post('/workflows/:owner:repo/:workflow_id/run', async (req, res) => {
 });
 
 // Cancel a workflow run
-router.post('/workflows/:owner:/repo/runs/:run_id/cancel', async (req, res) => {
+router.post('/workflows/:owner/:repo/runs/:run_id/cancel', async (req, res) => {
   try {
     const { owner, repo, run_id } = req.params;
 


### PR DESCRIPTION
## Summary
- fix typos in GitHub route paths
- correct minor syntax errors in route files

## Testing
- `node --check src/GitHubRoutes/repos.js`
- `node --check src/GitHubRoutes/settings.js`
- `node --check src/GitHubRoutes/deploys.js`
- `node --check src/GitHubRoutes/hooks.js`
- `node --check src/GitHubRoutes/workflows.js`
- `node --check src/GitHubRoutes/files.js`
- `node --check src/GitHubRoutes/issues.js`
- `node --check src/GitHubRoutes/codespaces.js`
- `node --check src/GitHubRoutes/gists.js`
- `node --check src/GitHubRoutes/secrets.js`
